### PR TITLE
feat[#9] : 권한 변경 api 구현

### DIFF
--- a/src/main/java/com/intren/auth/authentication/application/vaildator/LoginValidator.java
+++ b/src/main/java/com/intren/auth/authentication/application/vaildator/LoginValidator.java
@@ -16,7 +16,7 @@ public class LoginValidator {
     private final PasswordEncoderUtil passwordEncoderUtil;
 
     public User validateLogin(String username, String password) {
-        User user = userRepository.findByUsernmae(username);
+        User user = userRepository.findByUsername(username);
 
         if(!passwordEncoderUtil.isMatch(password, user.getPassword())){
             throw new AuthException(AuthErrorCode.INVALID_CREDENTIALS);

--- a/src/main/java/com/intren/auth/common/AuditorAwareImpl.java
+++ b/src/main/java/com/intren/auth/common/AuditorAwareImpl.java
@@ -1,10 +1,10 @@
 package com.intren.auth.common;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.NonNull;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 
 import java.util.Optional;
 
@@ -15,24 +15,19 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
     @Override
     @NonNull
     public Optional<Long> getCurrentAuditor() {
-        return Optional.of(getUserIdFromHeader());
-    }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-    public Long getUserIdFromHeader() {
-        ServletRequestAttributes attributes =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        if (attributes != null) {
-            HttpServletRequest request = attributes.getRequest();
-            String userId = request.getHeader("X-User-Id");
-            if (userId != null && !userId.isBlank()) {
-                try {
-                    return Long.parseLong(userId);
-                } catch (NumberFormatException e) {
-                    return 0L;
-                }
-            }
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.of(0L);
         }
 
-        return 0L;
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long userId) {
+            return Optional.of(userId);
+        }
+
+        return Optional.of(0L);
     }
+
 }

--- a/src/main/java/com/intren/auth/common/exception/ErrorResponse.java
+++ b/src/main/java/com/intren/auth/common/exception/ErrorResponse.java
@@ -9,4 +9,8 @@ public class ErrorResponse {
     public ErrorResponse(ErrorCode errorCode){
         this.error = new ErrorDetail(errorCode.name(), errorCode.getMessage());
     }
+
+    public ErrorResponse(ErrorCode errorCode, String message){
+        this.error = new ErrorDetail(errorCode.name(), message);
+    }
 }

--- a/src/main/java/com/intren/auth/common/init/AdminUserInit.java
+++ b/src/main/java/com/intren/auth/common/init/AdminUserInit.java
@@ -1,0 +1,27 @@
+package com.intren.auth.common.init;
+
+import com.intren.auth.authentication.infrastructure.password.PasswordEncoderUtil;
+import com.intren.auth.user.domain.model.User;
+import com.intren.auth.user.infrastructure.persistence.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AdminUserInit implements CommandLineRunner {
+    private final JpaUserRepository userRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if(!userRepository.existsByUsername("admin")) {
+            User admin = User.of(
+                    "admin",
+                    PasswordEncoderUtil.encode("1234"),
+                    "관리자"
+            );
+            admin.updateUserRoles();
+            userRepository.save(admin);
+        }
+    }
+}

--- a/src/main/java/com/intren/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/intren/auth/security/config/SecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity(securedEnabled = true)
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/intren/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/intren/auth/security/config/SecurityConfig.java
@@ -1,11 +1,14 @@
 package com.intren.auth.security.config;
 
 
+import com.intren.auth.security.exception.CustomAccessDeniedHandler;
+import com.intren.auth.security.exception.CustomAuthenticationEntryPoint;
 import com.intren.auth.security.filter.AuthFilter;
 import com.intren.auth.security.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -14,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -24,9 +28,12 @@ public class SecurityConfig {
         return http
                 .csrf(csrf ->csrf.disable())
                 .authorizeHttpRequests(auth ->auth
-                        .requestMatchers("/login", "signup").permitAll()
+                        .requestMatchers("/login", "/signup").permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex->ex
+                        .accessDeniedHandler(new CustomAccessDeniedHandler())
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .addFilterBefore(new AuthFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
                 .build();
 

--- a/src/main/java/com/intren/auth/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/intren/auth/security/exception/CustomAccessDeniedHandler.java
@@ -3,12 +3,10 @@ package com.intren.auth.security.exception;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.intren.auth.common.exception.ErrorResponse;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
@@ -22,7 +20,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(
             HttpServletRequest request,
             HttpServletResponse response,
-            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+            AccessDeniedException accessDeniedException) throws IOException{
         String message = getAccessDeniedMessage();
 
         ErrorResponse errorResponse = new ErrorResponse(SecurityErrorCode.ACCESS_DENIED, message);

--- a/src/main/java/com/intren/auth/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/intren/auth/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,46 @@
+package com.intren.auth.security.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.intren.auth.common.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        String message = getAccessDeniedMessage();
+
+        ErrorResponse errorResponse = new ErrorResponse(SecurityErrorCode.ACCESS_DENIED, message);
+        response.setStatus(SecurityErrorCode.ACCESS_DENIED.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+
+    private String getAccessDeniedMessage() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if(authentication != null&& authentication.isAuthenticated()) {
+            boolean isAdmin = authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+            if(!isAdmin) {
+                return "관리자 권한이 필요한 요청입니다. 접근 권한이 없습니다";
+            }
+        }
+        return "접근 권한이 없습니다.";
+    }
+}

--- a/src/main/java/com/intren/auth/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/intren/auth/security/exception/CustomAccessDeniedHandler.java
@@ -35,12 +35,15 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     private String getAccessDeniedMessage() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if(authentication != null&& authentication.isAuthenticated()) {
-            boolean isAdmin = authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
-            if(!isAdmin) {
-                return "관리자 권한이 필요한 요청입니다. 접근 권한이 없습니다";
+        if (authentication != null && authentication.isAuthenticated()) {
+            for (var authority : authentication.getAuthorities()) {
+                if ("ROLE_ADMIN".equals(authority.getAuthority())) {
+                    return "접근 권한이 없습니다.";
+                }
             }
+            return "관리자 권한이 필요한 요청입니다. 접근 권한이 없습니다";
         }
+
         return "접근 권한이 없습니다.";
     }
 }

--- a/src/main/java/com/intren/auth/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/intren/auth/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.intren.auth.security.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.intren.auth.common.exception.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void commence(
+          HttpServletRequest request,
+          HttpServletResponse response,
+          AuthenticationException authException) throws IOException, ServletException {
+          response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+          response.setContentType("application/json;charset=utf-8");
+          ErrorResponse errorResponse = new ErrorResponse(SecurityErrorCode.INVALID_TOKEN);
+          objectMapper.writeValue(response.getWriter(), errorResponse);
+  }
+}

--- a/src/main/java/com/intren/auth/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/intren/auth/security/exception/SecurityErrorCode.java
@@ -1,0 +1,28 @@
+package com.intren.auth.security.exception;
+
+import com.intren.auth.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum SecurityErrorCode implements ErrorCode {
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    SecurityErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/intren/auth/security/filter/AuthFilter.java
+++ b/src/main/java/com/intren/auth/security/filter/AuthFilter.java
@@ -34,7 +34,7 @@ public class AuthFilter implements Filter {
                         new UsernamePasswordAuthenticationToken(
                                 userId,
                                 null,
-                                List.of(new SimpleGrantedAuthority(role))
+                                List.of(new SimpleGrantedAuthority("ROLE_" + role))
                         );
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/intren/auth/user/application/dto/response/UpdateUserRolesResponseDto.java
+++ b/src/main/java/com/intren/auth/user/application/dto/response/UpdateUserRolesResponseDto.java
@@ -1,0 +1,30 @@
+package com.intren.auth.user.application.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateUserRolesResponseDto {
+    private final String username;
+    private final String nickname;
+    private final List<RoleResponseDto> roles;
+
+    public UpdateUserRolesResponseDto(
+            String username,
+            String nickname,
+            List<RoleResponseDto> roles
+    ){
+        this.username = username;
+        this.nickname = nickname;
+        this.roles = roles;
+    }
+
+    public static UpdateUserRolesResponseDto of(
+            String username,
+            String nickname,
+            List<RoleResponseDto> roles
+    ){
+        return new UpdateUserRolesResponseDto(username, nickname, roles);
+    }
+}

--- a/src/main/java/com/intren/auth/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/intren/auth/user/application/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package com.intren.auth.user.application.mapper;
 import com.intren.auth.user.application.dto.request.SignupRequestDto;
 import com.intren.auth.user.application.dto.response.RoleResponseDto;
 import com.intren.auth.user.application.dto.response.SignupResponseDto;
+import com.intren.auth.user.application.dto.response.UpdateUserRolesResponseDto;
 import com.intren.auth.user.domain.model.User;
 
 import java.util.List;
@@ -19,6 +20,14 @@ public class UserMapper {
 
     public static SignupResponseDto toResponseDto(User user) {
         return SignupResponseDto.of(
+                user.getUsername(),
+                user.getNickname(),
+                List.of(new RoleResponseDto(user.getRole()))
+        );
+    }
+
+    public static UpdateUserRolesResponseDto toUpdateRoleAdminResponseDto(User user) {
+        return UpdateUserRolesResponseDto.of(
                 user.getUsername(),
                 user.getNickname(),
                 List.of(new RoleResponseDto(user.getRole()))

--- a/src/main/java/com/intren/auth/user/application/service/UserService.java
+++ b/src/main/java/com/intren/auth/user/application/service/UserService.java
@@ -2,8 +2,11 @@ package com.intren.auth.user.application.service;
 
 import com.intren.auth.user.application.dto.request.SignupRequestDto;
 import com.intren.auth.user.application.dto.response.SignupResponseDto;
+import com.intren.auth.user.application.dto.response.UpdateUserRolesResponseDto;
 import jakarta.validation.Valid;
 
 public interface UserService {
     SignupResponseDto signup(@Valid SignupRequestDto requestDto);
+
+    UpdateUserRolesResponseDto updateUserRoles(Long userId);
 }

--- a/src/main/java/com/intren/auth/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/intren/auth/user/application/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.intren.auth.user.application.service;
 import com.intren.auth.authentication.infrastructure.password.PasswordEncoderUtil;
 import com.intren.auth.user.application.dto.request.SignupRequestDto;
 import com.intren.auth.user.application.dto.response.SignupResponseDto;
+import com.intren.auth.user.application.dto.response.UpdateUserRolesResponseDto;
 import com.intren.auth.user.application.mapper.UserMapper;
 import com.intren.auth.user.application.validator.DuplicateUserValidator;
 import com.intren.auth.user.domain.model.User;
@@ -27,5 +28,15 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
 
         return UserMapper.toResponseDto(user);
+    }
+
+    @Override
+    @Transactional
+    public UpdateUserRolesResponseDto updateUserRoles(Long userId) {
+        User user = userRepository.findById(userId);
+
+        user.updateUserRoles();
+
+        return UserMapper.toUpdateRoleAdminResponseDto(user);
     }
 }

--- a/src/main/java/com/intren/auth/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/intren/auth/user/domain/exception/UserErrorCode.java
@@ -5,7 +5,10 @@ import org.springframework.http.HttpStatus;
 
 public enum UserErrorCode implements ErrorCode {
 
-    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 사용자입니다.");
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND , "존재 하지 않는 사용자입니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/intren/auth/user/domain/exception/UserNotFoundException.java
+++ b/src/main/java/com/intren/auth/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.intren.auth.user.domain.exception;
+
+import com.intren.auth.common.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+    public UserNotFoundException() {
+        super(UserErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/intren/auth/user/domain/model/User.java
+++ b/src/main/java/com/intren/auth/user/domain/model/User.java
@@ -53,6 +53,10 @@ public class User extends BaseEntity {
         );
     }
 
+    public void updateUserRoles() {
+        this.role = UserRole.ADMIN;
+    }
+
 
 
 }

--- a/src/main/java/com/intren/auth/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/intren/auth/user/domain/repository/UserRepository.java
@@ -7,5 +7,7 @@ public interface UserRepository {
 
     void save(User user);
 
-    User findByUsernmae(String username);
+    User findByUsername(String username);
+
+    User findById(Long userId);
 }

--- a/src/main/java/com/intren/auth/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/intren/auth/user/infrastructure/repository/UserRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.intren.auth.user.infrastructure.repository;
 
 import com.intren.auth.authentication.domain.exception.AuthErrorCode;
 import com.intren.auth.authentication.domain.exception.AuthException;
-import com.intren.auth.user.domain.exception.UserErrorCode;
 import com.intren.auth.user.domain.exception.UserNotFoundException;
 import com.intren.auth.user.domain.model.User;
 import com.intren.auth.user.domain.repository.UserRepository;

--- a/src/main/java/com/intren/auth/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/intren/auth/user/infrastructure/repository/UserRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.intren.auth.user.infrastructure.repository;
 
 import com.intren.auth.authentication.domain.exception.AuthErrorCode;
 import com.intren.auth.authentication.domain.exception.AuthException;
+import com.intren.auth.user.domain.exception.UserErrorCode;
+import com.intren.auth.user.domain.exception.UserNotFoundException;
 import com.intren.auth.user.domain.model.User;
 import com.intren.auth.user.domain.repository.UserRepository;
 import com.intren.auth.user.infrastructure.persistence.JpaUserRepository;
@@ -25,8 +27,14 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public User findByUsernmae(String username) {
+    public User findByUsername(String username) {
         return jpaUserRepository.findByUsername(username)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_CREDENTIALS));
+    }
+
+    @Override
+    public User findById(Long userId) {
+        return jpaUserRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException());
     }
 }

--- a/src/main/java/com/intren/auth/user/presentation/UserController.java
+++ b/src/main/java/com/intren/auth/user/presentation/UserController.java
@@ -2,14 +2,14 @@ package com.intren.auth.user.presentation;
 
 import com.intren.auth.user.application.dto.request.SignupRequestDto;
 import com.intren.auth.user.application.dto.response.SignupResponseDto;
+import com.intren.auth.user.application.dto.response.UpdateUserRolesResponseDto;
 import com.intren.auth.user.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +24,14 @@ public class UserController {
         SignupResponseDto response = userService.signup(requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+
+    @Secured("ADMIN")
+    @PatchMapping("/admin/users/{userId}/roles")
+    public ResponseEntity<UpdateUserRolesResponseDto> updateUserRoles(
+            @Valid @PathVariable Long userId){
+        UpdateUserRolesResponseDto responseDto = userService.updateUserRoles(userId);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/intren/auth/user/presentation/UserController.java
+++ b/src/main/java/com/intren/auth/user/presentation/UserController.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,7 +27,7 @@ public class UserController {
     }
 
 
-    @Secured("ADMIN")
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/admin/users/{userId}/roles")
     public ResponseEntity<UpdateUserRolesResponseDto> updateUserRoles(
             @Valid @PathVariable Long userId){

--- a/src/test/resources/UpdateUserRoleTest.http
+++ b/src/test/resources/UpdateUserRoleTest.http
@@ -1,0 +1,6 @@
+### 권한 변경 요청
+PATCH http://localhost:8080/admin/users/2/roles
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3NDcyMjUwMjEsImV4cCI6MTc0NzIyODYyMX0.fFaf0XZ5JtgzjmG6bEioF1U2jNILdUgUL18hxIsGC8P
+
+###


### PR DESCRIPTION
## ✨ 변경 타입
* [X] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 권한 변경 API 구현했습니다.

* **세부 내용**
  * @Secured 어노테이션 적용하여 해당 메서드에 ADMIN 관리자만 접근 가능하도록 하였습니다
  * @Secured가 잘 되지 않아 @PreAuthorize로 변경하였습니다.
  * h2  인메모리 방식은 서버 구동 시 마다 초기화 되어 배포 시 admin 계정이 없어 해당 api에 토큰 기반으로 접근이 불가함으로 서버 실행 시 admin 계정을 생성합니다
